### PR TITLE
Prepare BudgetEase for public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Welcome to **Budget Ease**, a mobile app created by **Lucas Andersen** for the **2024-2025 FBLA Coding and Programming competition**. Budget Ease is designed to help students effectively manage their personal finances with ease and precision.
 
+🏆 **FBLA 2025 NLC National Contender**
+
+Budget Ease is gearing up for the **2025 FBLA National Leadership Conference (NLC)**. We're excited to showcase our project on the national stage!
+
 ---
 
 ## 🎯 Key Features 🔑
@@ -38,3 +42,12 @@ Welcome to **Budget Ease**, a mobile app created by **Lucas Andersen** for the *
 ## 🌟 Made with ❤️ by Lucas Andersen
 
 "Budget Ease simplifies student finances, offering the tools to spend smarter and save better!"
+
+## 🔑 API Key Setup
+
+To enable AI-powered features, supply your own Gemini API key by either:
+
+1. Creating a `local.properties` file with `geminiApiKey=YOUR_KEY`.
+2. Or setting the `GEMINI_API_KEY` environment variable.
+
+The repository does not include an API key for security reasons.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Expose Gemini API key to BuildConfig
+        val geminiApiKey = project.findProperty("geminiApiKey") as String? ?: System.getenv("GEMINI_API_KEY") ?: ""
+        buildConfigField("String", "GEMINI_API_KEY", "\"$geminiApiKey\"")
     }
 
     buildTypes {
@@ -34,6 +38,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        buildConfig = true
         viewBinding = true
     }
 }

--- a/app/src/main/java/com/llucasandersen/lucasfbla2025bankingapp/FinancesActivity.kt
+++ b/app/src/main/java/com/llucasandersen/lucasfbla2025bankingapp/FinancesActivity.kt
@@ -25,6 +25,7 @@ import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.ValueFormatter
 import com.google.android.material.navigation.NavigationView
+import com.llucasandersen.lucasfbla2025bankingapp.BuildConfig
 import com.itextpdf.text.Document
 import com.itextpdf.text.Image
 import com.itextpdf.text.Paragraph
@@ -52,7 +53,8 @@ import kotlin.math.abs
 
 class FinancesActivity : AppCompatActivity() {
 
-    private val geminiApiKey = "AIzaSyANCEYsx6C7oAPed3kgVojTdfJzF3IrgPI"
+    // Gemini API key is provided at build time through BuildConfig
+    private val geminiApiKey = BuildConfig.GEMINI_API_KEY
 
     private lateinit var lineChart: LineChart
     private lateinit var pieChart: PieChart

--- a/app/src/main/java/com/llucasandersen/lucasfbla2025bankingapp/HelpPagerAdapter.kt
+++ b/app/src/main/java/com/llucasandersen/lucasfbla2025bankingapp/HelpPagerAdapter.kt
@@ -15,6 +15,7 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import com.llucasandersen.lucasfbla2025bankingapp.BuildConfig
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
@@ -24,6 +25,9 @@ class HelpPagerAdapter(
     private val email: String?,
     private val onPageChange: (Int) -> Unit
 ) : RecyclerView.Adapter<HelpPagerAdapter.ViewHolder>() {
+
+    // Gemini API key provided via BuildConfig
+    private val geminiApiKey = BuildConfig.GEMINI_API_KEY
 
     private val pages = listOf(
         R.layout.help_page_welcome,
@@ -140,7 +144,7 @@ class HelpPagerAdapter(
                 }
 
                 val request = Request.Builder()
-                    .url("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=AIzaSyANCEYsx6C7oAPed3kgVojTdfJzF3IrgPI")
+                    .url("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=$geminiApiKey")
                     .addHeader("Content-Type", "application/json")
                     .post(RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), json.toString()))
                     .build()


### PR DESCRIPTION
## Summary
- remove embedded Gemini API keys from source
- read Gemini key from gradle property or environment variable
- enable BuildConfig generation and expose API key field
- update FinancesActivity and HelpPagerAdapter to use BuildConfig key
- add FBLA national contender note and API key instructions in README
